### PR TITLE
Add a minimal CDK example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@ tmp/
 
 # Jetbrains
 .idea/
+
+# npm
+node_modules/
+package-lock.json
+
+# cdk
+cdk.out/

--- a/examples/cdk/README.md
+++ b/examples/cdk/README.md
@@ -1,0 +1,12 @@
+# CDK Example
+
+This is an example of setting up a basic dashboard using CDK.
+It leverages the NewRelic::Observability::Dashboards plugin in CloudFormation for its deploy.
+
+# Usage
+
+- Begin with `npm i` in this directory
+- Log into your AWS on the command line. For simplicity, this example assumes you have set up a `~/.aws/config` file and have exported the proper profile as an `AWS_PROFILE` environment variable. If that is not right for you, you can alter the `deploy`, `destroy`, and `diff` commands in `package.json` to have the correct `cdk` flags for your setup.
+- To view just the CloudFormation json created, run `npm run synth`. Json will be output in the `cdk.out` directory.
+- To deploy the stack in the environment you're logged in to, run `npm run deploy`
+- To completely remove the stack, run `npm run destroy`.

--- a/examples/cdk/cdk.json
+++ b/examples/cdk/cdk.json
@@ -1,0 +1,17 @@
+{
+  "app": "npx ts-node -P tsconfig.json --prefer-ts-exts src/main.ts",
+  "output": "cdk.out",
+  "watch": {
+    "include": ["src/**/*.ts"],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules"
+    ]
+  }
+}

--- a/examples/cdk/package.json
+++ b/examples/cdk/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "newrelic-cloudformation-resource-providers-dashboards-example-cdk",
+  "scripts": {
+    "deploy": "cdk deploy",
+    "destroy": "cdk destroy",
+    "diff": "cdk diff",
+    "synth": "cdk synth"
+  },
+  "devDependencies": {
+    "aws-cdk": "^2.1.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "@cdk-cloudformation/newrelic-observability-dashboards": "^1.2.0-alpha.7",
+    "aws-cdk-lib": "^2.1.0",
+    "constructs": "^10.0.5"
+  },
+  "engines": {
+    "node": ">= 18.17.1"
+  },
+  "license": "APACHE-2.0",
+  "version": "1.0.0"
+}

--- a/examples/cdk/src/main.ts
+++ b/examples/cdk/src/main.ts
@@ -1,0 +1,9 @@
+import { App } from "aws-cdk-lib";
+
+import { DashboardStack } from "./stacks/stack";
+
+const app = new App();
+
+new DashboardStack(app, "newrelic-dashboard-cdk-example", {});
+
+app.synth();

--- a/examples/cdk/src/stacks/stack.ts
+++ b/examples/cdk/src/stacks/stack.ts
@@ -1,0 +1,48 @@
+import { Stack, StackProps, CfnOutput } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import { CfnDashboards } from "@cdk-cloudformation/newrelic-observability-dashboards";
+
+export class DashboardStack extends Stack {
+  constructor(scope: Construct, id: string, props: StackProps = {}) {
+    super(scope, id, props);
+
+    const buildADashboard = {
+      dashboard: {
+        description: "CloudFormation test dashboard",
+        name: "CloudFormation Test Dashboard",
+        pages: {
+          description: "TD PAGE",
+          name: "TD Page",
+          widgets: {
+            title: "Widget Title",
+            configuration: { markdown: { text: "Some Markdown" } },
+          },
+        },
+        permissions: "PUBLIC_READ_ONLY",
+      },
+    };
+
+    const dash = new CfnDashboards(this, "NewRelicDashboard", {
+      dashboard: this.toGqlString(buildADashboard),
+    });
+    new CfnOutput(this, "NewRelicDashboardGuid", {
+      exportName: "NewRelicDashCDKExampleGuid",
+      value: dash.attrGuid,
+    });
+  }
+
+  // This is a workaround to get a json-ified object into the correct GQL format
+  // There are GQL libraries that will do this for you, and you should probably use those.
+  // However, for a minimal example, I felt it best to go with fewer libraries.
+  private toGqlString(obj: any): string {
+    const firstPass = JSON.stringify(obj).replace(/\"([\w_-]+?)\"\:/g, "$1:");
+    const permissionsUpdated = firstPass.replace(
+      /permissions:\"([A-Z_]+)\"/g,
+      "permissions:$1"
+    );
+    const removeOuterBrace = permissionsUpdated
+      .substring(0, permissionsUpdated.lastIndexOf("}"))
+      .replace("{", "");
+    return removeOuterBrace;
+  }
+}

--- a/examples/cdk/tsconfig.json
+++ b/examples/cdk/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+    "alwaysStrict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "lib": ["es2019"],
+    "module": "CommonJS",
+    "noEmitOnError": false,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "stripInternal": true,
+    "target": "ES2019"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["cdk.out"]
+}


### PR DESCRIPTION
I got a working CDK example that is easy to parse and start with. It works with 1.1.0 of the plugin (maybe earlier, but that's the first that worked for me). I've added it to the examples directory, along with a README to get up and running.